### PR TITLE
Changed Swiss required players from 8 to 2

### DIFF
--- a/src/Tournament.ts
+++ b/src/Tournament.ts
@@ -641,9 +641,9 @@ class Swiss extends Tournament {
      */
     startEvent(): void {
 
-        // Need at least 8 players
-        if (this.players.length < 8) {
-            throw `Swiss tournaments require at least 8 players, and there are currently ${this.players.length} players enrolled.`;
+        // Need at least 2 players
+        if (this.players.length < 2) {
+            throw `Swiss tournaments require at least 2 players, and there are currently ${this.players.length} players enrolled.`;
         }
 
         // Set tournament as active


### PR DESCRIPTION
Since the Swiss algorithm changes amount of rounds based on player count, there was no reason to limit the mode to 8 players.
Local tournaments where this would be used could only get 4-6 participants, and then they would not be able to use the tools created with this.