### PR TITLE
Fix wrong path reference when exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
       "import": "./dist/index.js"
     },
     "./interfaces": "./dist/interfaces/index.js",
-    "./components": "./dist/components.index.js"
+    "./components": "./dist/components/index.js"
   },
   "types": "./dist/index.d.js",
   "files": [


### PR DESCRIPTION
The path referenced in the exports seems to be invalid. 