### PR TITLE
access components & interfaces from main entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "tournament-organizer",
   "version": "3.6.1",
   "description": "JavaScript library for running tournaments",
+  "main": "./dist/index.js",
   "exports": {
     ".": {
       "browser": "./dist/index.module.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
 import { Manager } from './components/Manager.js';
 
 export default Manager;
+
+export * from './components/index.js';
+export * from './interfaces/index.js';


### PR DESCRIPTION
For some reason in Vue 2.6 project, `import {} from tournament-organizer` or `import {} from tournament-organizer/components` or `import {} from tournament-organizer/interfaces` don't work. 

It throws errors such as `tournament-organizer` is not found or `tournament-organizer/components` is not found. This helps resolve the issue.