### PR TITLE
Calculate bye score

### DIFF
--- a/src/components/Tournament.ts
+++ b/src/components/Tournament.ts
@@ -333,7 +333,7 @@ export class Tournament {
                 return matchA.round - matchB.round;
             });
             player.player.matches.filter(match => this.matches.find(m => m.id === match.id && m.active === false)).forEach(match => {
-                player.gamePoints += match.bye ? this.scoring.bye : (this.scoring.win * match.win) + (this.scoring.loss * match.loss) + (this.scoring.draw * match.draw);
+                player.gamePoints += ((match.bye ? this.scoring.bye : this.scoring.win) * match.win) + (this.scoring.loss * match.loss) + (this.scoring.draw * match.draw);
                 player.games += match.win + match.loss + match.draw;
                 player.matchPoints += match.bye ? this.scoring.bye : match.win > match.loss ? this.scoring.win : match.loss > match.win ? this.scoring.loss : this.scoring.draw;
                 player.tiebreaks.cumulative += player.matchPoints;

--- a/src/components/Tournament.ts
+++ b/src/components/Tournament.ts
@@ -333,9 +333,9 @@ export class Tournament {
                 return matchA.round - matchB.round;
             });
             player.player.matches.filter(match => this.matches.find(m => m.id === match.id && m.active === false)).forEach(match => {
-                player.gamePoints += (this.scoring.win * match.win) + (this.scoring.loss * match.loss) + (this.scoring.draw * match.draw);
+                player.gamePoints += match.bye ? this.scoring.bye : (this.scoring.win * match.win) + (this.scoring.loss * match.loss) + (this.scoring.draw * match.draw);
                 player.games += match.win + match.loss + match.draw;
-                player.matchPoints += match.win > match.loss ? this.scoring.win : match.loss > match.win ? this.scoring.loss : this.scoring.draw;
+                player.matchPoints += match.bye ? this.scoring.bye : match.win > match.loss ? this.scoring.win : match.loss > match.win ? this.scoring.loss : this.scoring.draw;
                 player.tiebreaks.cumulative += player.matchPoints;
                 player.matches++;
             });


### PR DESCRIPTION
Currently, score formula does not seems to take into consideration of bye match/games. But the scoring configuration object has allowed to configure score for each bye match/game. So adjust the formula to add points in such cases.