### PR TITLE
fix: update players and matches types on TournamentValues

### DIFF
--- a/src/components/Manager.ts
+++ b/src/components/Manager.ts
@@ -2,7 +2,7 @@ import randomstring from 'randomstring';
 import { Match } from './Match.js';
 import { Tournament } from './Tournament.js';
 import { SettableTournamentValues } from '../interfaces/SettableTournamentValues.js';
-import { TournamentValues } from '../interfaces/TournamentValues.js';
+import { LoadableTournamentValues } from '../interfaces/LoadableTournamentValues.js';
 
 /** 
  * Class representing a tournament manager.
@@ -50,7 +50,7 @@ export class Manager {
      * @param tourney Plain object of a tournament
      * @returns The newly reloaded tournament
      */
-    reloadTournament(tourney: TournamentValues): Tournament {
+    reloadTournament(tourney: LoadableTournamentValues): Tournament {
         const tournament = new Tournament(tourney.id, tourney.name);
         tournament.settings = {
             round: tourney.round,

--- a/src/interfaces/LoadableTournamentValues.ts
+++ b/src/interfaces/LoadableTournamentValues.ts
@@ -1,0 +1,11 @@
+import { MatchValues } from "./MatchValues.js";
+import { PlayerValues } from "./PlayerValues.js";
+import { SettableTournamentValues } from "./SettableTournamentValues.js";
+import { TournamentValues } from "./TournamentValues.js";
+
+export interface LoadableTournamentValues
+  extends Omit<SettableTournamentValues, "matches" | "players"> {
+  id: TournamentValues["id"];
+  matches: Array<MatchValues>;
+  players: Array<PlayerValues>;
+}

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,3 +1,4 @@
+import { LoadableTournamentValues } from './LoadableTournamentValues.js';
 import { MatchValues } from './MatchValues.js';
 import { PlayerValues } from './PlayerValues.js';
 import { SettableMatchValues } from './SettableMatchValues.js';
@@ -7,6 +8,7 @@ import { StandingsValues } from './StandingsValues.js';
 import { TournamentValues } from './TournamentValues.js';
 
 export {
+    LoadableTournamentValues,
     MatchValues,
     PlayerValues,
     SettableMatchValues,


### PR DESCRIPTION
# Update players and matches types on TournamentValues

## The issue

If we try to reload a tournament based on the json we get some TypeScript errors on the `players` and `matches` attributes.

```
Type '{ id: string; name: string; active: true; value: number; matches: never[]; meta: {}; }' is missing the following properties from type 'Player': values, addMatch, removeMatch, updateMatch ts(2739)
```

This is due that `players` and `matches` attributes on `TournamentValues` currently expects an instance of `Player` and `Match`. Which include the methods.

I believe that is not the intended behaviour since it should expect a serialized json in order to create the instances.

### How to reproduce
```ts
import TournamentOrganizer from "tournament-organizer";

const t = new TournamentOrganizer();

const tournament = t.reloadTournament({
  id: "Y6tuElkIdxtH",
  name: "Dutch Pauper League",
  status: "setup",
  round: 0,
  players: [
    {
      id: "4luLJp50nru7",
      name: "Lucas",
      active: true,
      value: 0,
      matches: [],
      meta: {},
    },
  ],
  matches: [],
  colored: false,
  sorting: "none",
  scoring: {
    bestOf: 3,
    win: 3,
    draw: 1,
    loss: 0,
    bye: 3,
    tiebreaks: [],
  },
  stageOne: {
    format: "swiss",
    consolation: false,
    rounds: 0,
    initialRound: 1,
    maxPlayers: 0,
  },
  stageTwo: {
    format: null,
    consolation: false,
    advance: { value: 0, method: "all" },
  },
  meta: {},
});

```

## Solution

I've updated the types on `TournamentValues` to use `MatchValues` and `PlayerValues` respectively. 
And on `Tournament` interface to use `Match` and `Player` types.

## Attention

I tried to update the docs, but if I build from my local machine it will reference commits from my forked repository instead of the base repository.

If this solution make sense and you merge it, could you please update the docs for me?
