### PR TITLE
Fix createMatches() player score calculation

### DIFF
--- a/src/components/Tournament.ts
+++ b/src/components/Tournament.ts
@@ -246,7 +246,7 @@ export class Tournament {
                 case 'swiss':
                     const playerArray = players.map(player => ({
                         id: player.id,
-                        score: player.matches.reduce((sum, match) => match.win > match.loss ? sum + this.scoring.win : match.loss > match.win ? sum + this.scoring.loss : sum + this.scoring.draw, 0),
+                        score: player.matches.reduce((sum, match) => sum += match.bye ? this.scoring.bye : match.win > match.loss ? this.scoring.win : match.loss > match.win ? this.scoring.loss : this.scoring.draw, 0),
                         pairedUpDown: player.matches.some(match => match.pairUpDown === true),
                         receivedBye: player.matches.some(match => match.bye === true),
                         avoid: player.matches.map(match => match.opponent).filter(opp => opp !== null),

--- a/src/components/Tournament.ts
+++ b/src/components/Tournament.ts
@@ -246,7 +246,7 @@ export class Tournament {
                 case 'swiss':
                     const playerArray = players.map(player => ({
                         id: player.id,
-                        score: player.matches.reduce((sum, match) => match.win > match.loss ? sum + this.scoring.win : match.loss > match.win ? sum + this.scoring.loss : this.scoring.draw, 0),
+                        score: player.matches.reduce((sum, match) => match.win > match.loss ? sum + this.scoring.win : match.loss > match.win ? sum + this.scoring.loss : sum + this.scoring.draw, 0),
                         pairedUpDown: player.matches.some(match => match.pairUpDown === true),
                         receivedBye: player.matches.some(match => match.bye === true),
                         avoid: player.matches.map(match => match.opponent).filter(opp => opp !== null),


### PR DESCRIPTION
When creating matches, the calculation of the player score seems to be wrong. Namely two issues could be identified with the following scoring configuration:

* Bye: 1
* Draw: 0
* Loss: 0
* Win: 1

First, draws seem to reset the score completely, since a player, who played the following series of matches *m = [win, win, draw, win, win]*, will have a score of *2* instead of the expected *4*.

Second, byes do not seem to be included at all, since a player, who played *m = [win, bye, win, win]*, gets a score of *3* instead of the expected *4*.

This PR fixes both issues by replacing [the current score calculation](https://github.com/slashinfty/tournament-organizer/blob/0b7fd935ffab59f6c2ec0be6e49af4931786579d/src/components/Tournament.ts#L249), with a new one, which is similar to [the one used when computing the standing-scores](https://github.com/slashinfty/tournament-organizer/blob/0b7fd935ffab59f6c2ec0be6e49af4931786579d/src/components/Tournament.ts#L343).