### PR TITLE
Add main entry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "tournament-organizer",
   "version": "3.8.1",
   "description": "JavaScript library for running tournaments",
+  "main": "./dist/index.js",
   "exports": {
     ".": {
       "browser": "./dist/index.module.js",


### PR DESCRIPTION
According to npm document [here](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#main), when the main entry file is not index.js at the root directory, it has to be specified using "main".

In this case, main entry is dist/index.js, so it's better to update it.