### PR TITLE
jsdoc for tournament seating option

### DIFF
--- a/src/components/Tournament.ts
+++ b/src/components/Tournament.ts
@@ -33,7 +33,12 @@ export class Tournament {
     /** All matches of the tournament */
     #matches: TournamentValues['matches'];
 
-    /** If order of players in matches matters */
+    /**
+     * If the order of players in matches matters.
+     * If enabled, this will switch players' seating before a match begins
+     * to help balance color assignments and prevent players from playing the same color too often.
+     * Initialized as `false`
+     */
     #seating: TournamentValues['seating'];
 
     /** Sorting method, if players are rated/seeded */

--- a/src/interfaces/SettableTournamentValues.ts
+++ b/src/interfaces/SettableTournamentValues.ts
@@ -13,6 +13,13 @@ export interface SettableTournamentValues {
     status?: 'setup' | 'stage-one' | 'stage-two' | 'complete',
     round?: number,
     matches?: Array<Match>,
+
+    /**
+     * If the order of players in matches matters.
+     * If enabled, this will switch players' seating before a match begins
+     * to help balance color assignments and prevent players from playing the same color too often.
+     * Initialized as `false`
+     */
     seating?: boolean,
     sorting?: 'ascending' | 'descending' | 'none',
     scoring?: {

--- a/src/interfaces/TournamentValues.ts
+++ b/src/interfaces/TournamentValues.ts
@@ -39,7 +39,8 @@ export interface TournamentValues {
     matches: Array<Match>,
     /**
      * If the order of players in matches matters.
-     * 
+     * If enabled, this will switch players' seating before a match begins
+     * to help balance color assignments and prevent players from playing the same color too often.
      * Initialized as `false`
      */
     seating: boolean,


### PR DESCRIPTION
There is 3 places where the `seating` option is defined. 2 places was documented, but the missing one is the one it needs to have useful doc on IDE when using `.createTournament`